### PR TITLE
Change/not found is success

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,5 @@ var request = Request.Get("...", acceptNotFound: false);
 var response = await odata.SendAsync(request);
 ```
 
-When a response code of other HTTP method, like as POST,PUT,PATCH and DELETE, is 404, ODataHttpClient set `Response.Success` false.
+When a response code of other HTTP methods, like as POST,PUT,PATCH and DELETE, is 404, ODataHttpClient set `Response.Success` false.
 

--- a/README.md
+++ b/README.md
@@ -133,16 +133,12 @@ If you change general json format, can select a way of three.
 
 ## NotFound(404)
 
-In default, ODataHttpClient decide 404 response code to success. If you change to error, can select a way of followings.
+In default, ODataHttpClient decide 404 response code of GET and HEAD request to success. If you change to error, can select a way of followings.
 
-### 1. Global level settings
+```
+var request = Request.Get("...", acceptNotFound: false);
+var response = await odata.SendAsync(request);
+```
 
-    ODataHttpClient.DefaultNotFoundIsSuccess = false;
+When a response code of other HTTP method, like as POST,PUT,PATCH and DELETE, is 404, ODataHttpClient set `Response.Success` false.
 
-### 2. Instance level settings
-
-    var odata = new ODataHttpClient(httpClient) { NotFoundIsSuccess = false };
-
-### 3. Request level settings
-
-    var response = await odata.SendAsync(request, notfoundIsSuccess: false);

--- a/src/ODataHttpClient.Tests/SenarioTest.cs
+++ b/src/ODataHttpClient.Tests/SenarioTest.cs
@@ -148,5 +148,68 @@ namespace ODataHttpClient.Tests
 
             Assert.Null(product);
         }
+
+        
+        [Fact]
+        public async Task SuccessAtNotFoundByGet()
+        {
+            var response = await odata.SendAsync(Request.Get($"{endpoint}/Products(@Id)", new { Id = -1 }));
+
+            Assert.True(response.Success);
+
+            var product = response.ReadAs<dynamic>();
+
+            Assert.Null(product);
+        }
+
+        [Fact]
+        public async Task FailedAtNotFoundByGetWithFlag()
+        {
+            var response = await odata.SendAsync(Request.Get($"{endpoint}/Products(@Id)", new { Id = -1 }, false));
+
+            Assert.False(response.Success);
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task FailedAtNotFoundByPost()
+        {
+            var response = await odata.SendAsync(Request.Put($"{endpoint}/Product", new { }, new {}, type:"ODataDemo.Product"));
+
+            Assert.False(response.Success);
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task FailedAtNotFoundByPut()
+        {
+            var response = await odata.SendAsync(Request.Put($"{endpoint}/Products(@Id)", new { Id = -1 }, new {}, type:"ODataDemo.Product"));
+
+            Assert.False(response.Success);
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task FailedAtNotFoundByPatch()
+        {
+            var response = await odata.SendAsync(Request.Patch($"{endpoint}/Products(@Id)", new { Id = -1 }, new {}, type:"ODataDemo.Product"));
+
+            Assert.False(response.Success);
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task FailedAtNotFoundByDelete()
+        {
+            var response = await odata.SendAsync(Request.Delete($"{endpoint}/Products(@Id)", new { Id = -1 }));
+
+            Assert.False(response.Success);
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
     }
 }

--- a/src/ODataHttpClient.Tests/SenarioV4Test.cs
+++ b/src/ODataHttpClient.Tests/SenarioV4Test.cs
@@ -176,7 +176,7 @@ namespace ODataHttpClient.Tests
         [Fact]
         public async Task FailedAtNotFoundByGetWithFlag()
         {
-            var response = await odata.SendAsync(Request.Get($"{endpoint}/Products(@Id)", new { Id = -1 }, notfoundIsSuccess:false));
+            var response = await odata.SendAsync(Request.Get($"{endpoint}/Products(@Id)", new { Id = -1 }, acceptNotFound:false));
 
             Assert.False(response.Success);
 

--- a/src/ODataHttpClient.Tests/SenarioV4Test.cs
+++ b/src/ODataHttpClient.Tests/SenarioV4Test.cs
@@ -160,5 +160,67 @@ namespace ODataHttpClient.Tests
 
             Assert.True(products.Count() > 0);
         }
+
+        [Fact]
+        public async Task SuccessAtNotFoundByGet()
+        {
+            var response = await odata.SendAsync(Request.Get($"{endpoint}/Products(@Id)", new { Id = -1 }));
+
+            Assert.True(response.Success);
+
+            var product = response.ReadAs<dynamic>();
+
+            Assert.Null(product);
+        }
+
+        [Fact]
+        public async Task FailedAtNotFoundByGetWithFlag()
+        {
+            var response = await odata.SendAsync(Request.Get($"{endpoint}/Products(@Id)", new { Id = -1 }, notfoundIsSuccess:false));
+
+            Assert.False(response.Success);
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task FailedAtNotFoundByPost()
+        {
+            var response = await odata.SendAsync(Request.Put($"{endpoint}/Product", new { }, new {}, type:"ODataDemo.Product", typeKey: "@odata.type"));
+
+            Assert.False(response.Success);
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task FailedAtNotFoundByPut()
+        {
+            var response = await odata.SendAsync(Request.Put($"{endpoint}/Products(@Id)", new { Id = -1 }, new {}, type:"ODataDemo.Product", typeKey: "@odata.type"));
+
+            Assert.False(response.Success);
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task FailedAtNotFoundByPatch()
+        {
+            var response = await odata.SendAsync(Request.Patch($"{endpoint}/Products(@Id)", new { Id = -1 }, new {}, type:"ODataDemo.Product", typeKey: "@odata.type"));
+
+            Assert.False(response.Success);
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task FailedAtNotFoundByDelete()
+        {
+            var response = await odata.SendAsync(Request.Delete($"{endpoint}/Products(@Id)", new { Id = -1 }));
+
+            Assert.False(response.Success);
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        }
     }
 }

--- a/src/ODataHttpClient/Models/BatchRequest.cs
+++ b/src/ODataHttpClient/Models/BatchRequest.cs
@@ -11,8 +11,8 @@ namespace ODataHttpClient.Models
         public string Uri { get; }
         public ICollection<Request> Requests { get; set; }
         public IReadOnlyDictionary<string, string> Headers { get; private set; }
-        public bool NotFoundIsSuccess => false;
-        public bool[] NotFoundIsSuccesses => Requests.Select((req) => req.NotFoundIsSuccess).ToArray();
+        public bool AcceptNotFound => false;
+        public bool[] AcceptNotFounds => Requests.Select((req) => req.AcceptNotFound).ToArray();
         public BatchRequest(string uri)
         {
             Uri = uri;

--- a/src/ODataHttpClient/Models/BatchRequest.cs
+++ b/src/ODataHttpClient/Models/BatchRequest.cs
@@ -11,6 +11,8 @@ namespace ODataHttpClient.Models
         public string Uri { get; }
         public ICollection<Request> Requests { get; set; }
         public IReadOnlyDictionary<string, string> Headers { get; private set; }
+        public bool NotFoundIsSuccess => false;
+        public bool[] NotFoundIsSuccesses => Requests.Select((req) => req.NotFoundIsSuccess).ToArray();
         public BatchRequest(string uri)
         {
             Uri = uri;

--- a/src/ODataHttpClient/Models/IBatchRequest.cs
+++ b/src/ODataHttpClient/Models/IBatchRequest.cs
@@ -4,6 +4,6 @@ namespace ODataHttpClient.Models
 {
     public  interface IBatchRequest : IRequest
     {
-        bool[] NotFoundIsSuccesses { get;}
+        bool[] AcceptNotFounds { get;}
     }
 }

--- a/src/ODataHttpClient/Models/IBatchRequest.cs
+++ b/src/ODataHttpClient/Models/IBatchRequest.cs
@@ -4,5 +4,6 @@ namespace ODataHttpClient.Models
 {
     public  interface IBatchRequest : IRequest
     {
+        bool[] NotFoundIsSuccesses { get;}
     }
 }

--- a/src/ODataHttpClient/Models/IRequest.cs
+++ b/src/ODataHttpClient/Models/IRequest.cs
@@ -5,6 +5,6 @@ namespace ODataHttpClient.Models
     public interface IRequest
     {
         HttpRequestMessage CreateMessage();
-        bool NotFoundIsSuccess { get; }
+        bool AcceptNotFound { get; }
     }
 }

--- a/src/ODataHttpClient/Models/IRequest.cs
+++ b/src/ODataHttpClient/Models/IRequest.cs
@@ -2,8 +2,9 @@ using System.Net.Http;
 
 namespace ODataHttpClient.Models
 {
-    public  interface IRequest
+    public interface IRequest
     {
         HttpRequestMessage CreateMessage();
+        bool NotFoundIsSuccess { get; }
     }
 }

--- a/src/ODataHttpClient/Models/Request.cs
+++ b/src/ODataHttpClient/Models/Request.cs
@@ -19,6 +19,7 @@ namespace ODataHttpClient.Models
         public string Uri { get; private set; }
         public string MediaType { get; private set; }
         public string Body { get; private set; }
+        public bool NotFoundIsSuccess { get; private set; }
 
         private Request() { }
 
@@ -42,33 +43,35 @@ namespace ODataHttpClient.Models
             return message;
         }
 
-        public static Request Create(HttpMethod method, string uri)
-        {
-            return new Request
-            {
-                Method = method,
-                Uri = uri,
-                Body = null
-            };
-        }
-
-        public static Request Create(HttpMethod method, string uri, IReadOnlyDictionary<string, string> headers)
+        public static Request Create(HttpMethod method, string uri, bool notfoundIsSuccess = false)
         {
             return new Request
             {
                 Method = method,
                 Uri = uri,
                 Body = null,
-                Headers = headers
+                NotFoundIsSuccess = notfoundIsSuccess,
             };
         }
 
-        public static Request Create<T>(HttpMethod method, string uri, T body, string type = null, string typeKey = DEFAULT_TYPE_KEY, IJsonSerializer serializer = null, IReadOnlyDictionary<string, string> headers = null)
+        public static Request Create(HttpMethod method, string uri, IReadOnlyDictionary<string, string> headers, bool notfoundIsSuccess = false)
         {
-            return Create(method, uri, body, type != null ? new[] { new KeyValuePair<string, object>(typeKey, type) } : null, serializer ?? JsonSerializer.Default, headers);
+            return new Request
+            {
+                Method = method,
+                Uri = uri,
+                Body = null,
+                Headers = headers,
+                NotFoundIsSuccess = notfoundIsSuccess,
+            };
         }
 
-        public static Request Create<T>(HttpMethod method, string uri, T body, IEnumerable<KeyValuePair<string, object>> additionals, IJsonSerializer serializer, IReadOnlyDictionary<string, string> headers = null)
+        public static Request Create<T>(HttpMethod method, string uri, T body, string type = null, string typeKey = DEFAULT_TYPE_KEY, IJsonSerializer serializer = null, IReadOnlyDictionary<string, string> headers = null, bool notfoundIsSuccess = false)
+        {
+            return Create(method, uri, body, type != null ? new[] { new KeyValuePair<string, object>(typeKey, type) } : null, serializer ?? JsonSerializer.Default, headers, notfoundIsSuccess);
+        }
+
+        public static Request Create<T>(HttpMethod method, string uri, T body, IEnumerable<KeyValuePair<string, object>> additionals, IJsonSerializer serializer, IReadOnlyDictionary<string, string> headers = null, bool notfoundIsSuccess = false)
         {
             string content, mime = null;
 
@@ -96,25 +99,26 @@ namespace ODataHttpClient.Models
                 Uri = uri,
                 MediaType = mime,
                 Body = content,
-                Headers = headers
+                Headers = headers,
+                NotFoundIsSuccess = notfoundIsSuccess,
             };
         }
 
         public static IParameterizer Parameterizer { get; set; } = new ODataParameterizer();
 
-        public static Request Get(string uri) => Create(HttpMethod.Get, uri);
-        public static Request Get(string uri, object @params) => Get(Parameterizer.Parameterize(uri, @params));
-        public static Request Get(string uri, IReadOnlyDictionary<string, string> headers) => Create(HttpMethod.Get, uri, headers);
-        public static Request Get(string uri, object @params, IReadOnlyDictionary<string, string> headers) => Get(Parameterizer.Parameterize(uri, @params), headers);
+        public static Request Get(string uri, bool notfoundIsSuccess = true) => Create(HttpMethod.Get, uri, notfoundIsSuccess);
+        public static Request Get(string uri, object @params, bool notfoundIsSuccess = true) => Get(Parameterizer.Parameterize(uri, @params), notfoundIsSuccess);
+        public static Request Get(string uri, IReadOnlyDictionary<string, string> headers, bool notfoundIsSuccess = true) => Create(HttpMethod.Get, uri, headers, notfoundIsSuccess);
+        public static Request Get(string uri, object @params, IReadOnlyDictionary<string, string> headers, bool notfoundIsSuccess = true) => Get(Parameterizer.Parameterize(uri, @params), headers, notfoundIsSuccess);
 
-        public static Request Head(string uri) => Create(HttpMethod.Head, uri);
-        public static Request Head(string uri, object @params) => Head(Parameterizer.Parameterize(uri, @params));
-        public static Request Head(string uri, IReadOnlyDictionary<string, string> headers) => Create(HttpMethod.Head, uri, headers);
-        public static Request Head(string uri, object @params, IReadOnlyDictionary<string, string> headers) => Head(Parameterizer.Parameterize(uri, @params), headers);
+        public static Request Head(string uri, bool notfoundIsSuccess = true) => Create(HttpMethod.Head, uri, notfoundIsSuccess);
+        public static Request Head(string uri, object @params, bool notfoundIsSuccess = true) => Head(Parameterizer.Parameterize(uri, @params), notfoundIsSuccess);
+        public static Request Head(string uri, IReadOnlyDictionary<string, string> headers, bool notfoundIsSuccess = true) => Create(HttpMethod.Head, uri, headers, notfoundIsSuccess);
+        public static Request Head(string uri, object @params, IReadOnlyDictionary<string, string> headers, bool notfoundIsSuccess = true) => Head(Parameterizer.Parameterize(uri, @params), headers, notfoundIsSuccess);
 
         public static Request Delete(string uri) => Create(HttpMethod.Delete, uri);
         public static Request Delete(string uri, object @params) => Delete(Parameterizer.Parameterize(uri, @params));
-        public static Request Delete(string uri, IReadOnlyDictionary<string, string> headers) => Create(HttpMethod.Delete, uri, headers);
+        public static Request Delete(string uri, IReadOnlyDictionary<string, string> headers) => Create(HttpMethod.Delete, uri, headers, false);
         public static Request Delete(string uri, object @params, IReadOnlyDictionary<string, string> headers) => Delete(Parameterizer.Parameterize(uri, @params), headers);
 
         public static Request Post<T>(string uri, T body, string type = null, string typeKey = DEFAULT_TYPE_KEY, IJsonSerializer serializer = null)

--- a/src/ODataHttpClient/Models/Request.cs
+++ b/src/ODataHttpClient/Models/Request.cs
@@ -19,7 +19,7 @@ namespace ODataHttpClient.Models
         public string Uri { get; private set; }
         public string MediaType { get; private set; }
         public string Body { get; private set; }
-        public bool NotFoundIsSuccess { get; private set; }
+        public bool AcceptNotFound { get; private set; }
 
         private Request() { }
 
@@ -43,18 +43,18 @@ namespace ODataHttpClient.Models
             return message;
         }
 
-        public static Request Create(HttpMethod method, string uri, bool notfoundIsSuccess = false)
+        public static Request Create(HttpMethod method, string uri, bool acceptNotFound = false)
         {
             return new Request
             {
                 Method = method,
                 Uri = uri,
                 Body = null,
-                NotFoundIsSuccess = notfoundIsSuccess,
+                AcceptNotFound = acceptNotFound,
             };
         }
 
-        public static Request Create(HttpMethod method, string uri, IReadOnlyDictionary<string, string> headers, bool notfoundIsSuccess = false)
+        public static Request Create(HttpMethod method, string uri, IReadOnlyDictionary<string, string> headers, bool acceptNotFound = false)
         {
             return new Request
             {
@@ -62,16 +62,16 @@ namespace ODataHttpClient.Models
                 Uri = uri,
                 Body = null,
                 Headers = headers,
-                NotFoundIsSuccess = notfoundIsSuccess,
+                AcceptNotFound = acceptNotFound,
             };
         }
 
-        public static Request Create<T>(HttpMethod method, string uri, T body, string type = null, string typeKey = DEFAULT_TYPE_KEY, IJsonSerializer serializer = null, IReadOnlyDictionary<string, string> headers = null, bool notfoundIsSuccess = false)
+        public static Request Create<T>(HttpMethod method, string uri, T body, string type = null, string typeKey = DEFAULT_TYPE_KEY, IJsonSerializer serializer = null, IReadOnlyDictionary<string, string> headers = null, bool acceptNotFound = false)
         {
-            return Create(method, uri, body, type != null ? new[] { new KeyValuePair<string, object>(typeKey, type) } : null, serializer ?? JsonSerializer.Default, headers, notfoundIsSuccess);
+            return Create(method, uri, body, type != null ? new[] { new KeyValuePair<string, object>(typeKey, type) } : null, serializer ?? JsonSerializer.Default, headers, acceptNotFound);
         }
 
-        public static Request Create<T>(HttpMethod method, string uri, T body, IEnumerable<KeyValuePair<string, object>> additionals, IJsonSerializer serializer, IReadOnlyDictionary<string, string> headers = null, bool notfoundIsSuccess = false)
+        public static Request Create<T>(HttpMethod method, string uri, T body, IEnumerable<KeyValuePair<string, object>> additionals, IJsonSerializer serializer, IReadOnlyDictionary<string, string> headers = null, bool acceptNotFound = false)
         {
             string content, mime = null;
 
@@ -100,21 +100,21 @@ namespace ODataHttpClient.Models
                 MediaType = mime,
                 Body = content,
                 Headers = headers,
-                NotFoundIsSuccess = notfoundIsSuccess,
+                AcceptNotFound = acceptNotFound,
             };
         }
 
         public static IParameterizer Parameterizer { get; set; } = new ODataParameterizer();
 
-        public static Request Get(string uri, bool notfoundIsSuccess = true) => Create(HttpMethod.Get, uri, notfoundIsSuccess);
-        public static Request Get(string uri, object @params, bool notfoundIsSuccess = true) => Get(Parameterizer.Parameterize(uri, @params), notfoundIsSuccess);
-        public static Request Get(string uri, IReadOnlyDictionary<string, string> headers, bool notfoundIsSuccess = true) => Create(HttpMethod.Get, uri, headers, notfoundIsSuccess);
-        public static Request Get(string uri, object @params, IReadOnlyDictionary<string, string> headers, bool notfoundIsSuccess = true) => Get(Parameterizer.Parameterize(uri, @params), headers, notfoundIsSuccess);
+        public static Request Get(string uri, bool acceptNotFound = true) => Create(HttpMethod.Get, uri, acceptNotFound);
+        public static Request Get(string uri, object @params, bool acceptNotFound = true) => Get(Parameterizer.Parameterize(uri, @params), acceptNotFound);
+        public static Request Get(string uri, IReadOnlyDictionary<string, string> headers, bool acceptNotFound = true) => Create(HttpMethod.Get, uri, headers, acceptNotFound);
+        public static Request Get(string uri, object @params, IReadOnlyDictionary<string, string> headers, bool acceptNotFound = true) => Get(Parameterizer.Parameterize(uri, @params), headers, acceptNotFound);
 
-        public static Request Head(string uri, bool notfoundIsSuccess = true) => Create(HttpMethod.Head, uri, notfoundIsSuccess);
-        public static Request Head(string uri, object @params, bool notfoundIsSuccess = true) => Head(Parameterizer.Parameterize(uri, @params), notfoundIsSuccess);
-        public static Request Head(string uri, IReadOnlyDictionary<string, string> headers, bool notfoundIsSuccess = true) => Create(HttpMethod.Head, uri, headers, notfoundIsSuccess);
-        public static Request Head(string uri, object @params, IReadOnlyDictionary<string, string> headers, bool notfoundIsSuccess = true) => Head(Parameterizer.Parameterize(uri, @params), headers, notfoundIsSuccess);
+        public static Request Head(string uri, bool acceptNotFound = true) => Create(HttpMethod.Head, uri, acceptNotFound);
+        public static Request Head(string uri, object @params, bool acceptNotFound = true) => Head(Parameterizer.Parameterize(uri, @params), acceptNotFound);
+        public static Request Head(string uri, IReadOnlyDictionary<string, string> headers, bool acceptNotFound = true) => Create(HttpMethod.Head, uri, headers, acceptNotFound);
+        public static Request Head(string uri, object @params, IReadOnlyDictionary<string, string> headers, bool acceptNotFound = true) => Head(Parameterizer.Parameterize(uri, @params), headers, acceptNotFound);
 
         public static Request Delete(string uri) => Create(HttpMethod.Delete, uri);
         public static Request Delete(string uri, object @params) => Delete(Parameterizer.Parameterize(uri, @params));


### PR DESCRIPTION
* Remove the param from SendAsync And BatchAsync
* Add the param into IRequest and IBatchRequest
* Default behaviors
  - GET success
  - HEAD success
  - POST failed
  - PUT failed
  - PATCH failed
  - DELETE failed
* GET and HEAD can  change the behavior, Others cannot change it.
* rename notfoundIsSuccess acceptNotFound